### PR TITLE
fix(readme): remove buildserviceprovider call

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Example implementation 1
             Console.WriteLine("\u2705 Cache: Memory cache setup successful");
         }
 
-        var cacheProvider = (ICacheProvider)serviceProvider.BuildServiceProvider().GetService(typeof(ICacheProvider));
-        serviceProvider.AddSingleton(s => new CacheHelper(cacheProvider));
+        serviceProvider.AddSingleton<CacheHelper>();
     }
 ```
 
@@ -84,8 +83,7 @@ Example Implementation 2
                 Console.WriteLine("\u2705 Cache: Memory cache setup successful");
             }
 
-            var cacheProvider = (ICacheProvider)serviceProvider.BuildServiceProvider().GetService(typeof(ICacheProvider));
-            serviceProvider.AddSingleton(s => new CacheHelper(cacheProvider!));
+            serviceProvider.AddSingleton<CacheHelper>();
         }
 ```
 


### PR DESCRIPTION
The BuildServiceProvider method call creates a separate COPY of the ServiceProvider and injects in CacheHelper(creating separate shared memory caches).

https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0000?view=aspnetcore-8.0#rule-description